### PR TITLE
Fix duplicate block in __init__

### DIFF
--- a/src/deefuse/__init__.py
+++ b/src/deefuse/__init__.py
@@ -14,19 +14,3 @@ __all__ = [
 ]
 
 __version__ = "0.1.0"
-"""
-deefuse package root.
-
-Re-exports the most useful sub-modules for library users
-and defines the package version.
-"""
-__all__ = [
-    "config",
-    "utils",
-    "csv_handler",
-    "deezer_api",
-    "downloader",
-    "ui",
-]
-
-__version__ = "0.1.0"


### PR DESCRIPTION
## Summary
- remove a duplicated section from `src/deefuse/__init__.py`
- keep single definitions for `__all__` and `__version__`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686efba762c4832abb99c6727c3f6398