### PR TITLE
fix pyinstaller import

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build EXE with PyInstaller
         run: |
           python -m pip install --upgrade pip pyinstaller
-          pyinstaller --noconsole --onefile -n DeeFuse src/deefuse/__main__.py
+          pyinstaller --noconsole --onefile -n DeeFuse -m deefuse
       - name: Upload EXE to release
         uses: softprops/action-gh-release@v1
         with:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ pip install .
 
 This will install a `deefuse` entry point.
 
+## Building a standalone executable
+
+Use PyInstaller's module mode to bundle the application:
+
+```bash
+pyinstaller --noconsole --onefile -n DeeFuse -m deefuse
+```
+
+Running in module mode ensures the package context is correctly set when the
+executable starts.
+
 ## Usage
 
 Run the program either with the installed command or via the module:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,6 @@ dependencies = [
 
 [project.scripts]
 deefuse = "deefuse.__main__:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/deefuse/__main__.py
+++ b/src/deefuse/__main__.py
@@ -1,4 +1,4 @@
-from .ui.main_window import App   # relative import (the dot is important)
+from deefuse.ui.main_window import App
 
 
 def main() -> None:               # noqa: D401


### PR DESCRIPTION
## Summary
- reference the main GUI with an absolute import
- search for packages under `src/`
- build the Windows executable by running PyInstaller in module mode
- document the PyInstaller command in the README
- remove the stray root `src` package

## Testing
- `python -m py_compile $(git ls-files '*.py')`