### PR TITLE
Fix packaging and build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ pip install .
 
 This will install a `deefuse` entry point.
 
+## Building a standalone executable
+
+Bundle the app with PyInstaller:
+
+```bash
+pyinstaller --noconsole --onefile -n DeeFuse src/deefuse/__main__.py
+```
+
+The entry point uses absolute imports so the packaged executable starts
+correctly.
+
 ## Usage
 
 Run the program either with the installed command or via the module:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,6 @@ dependencies = [
 
 [project.scripts]
 deefuse = "deefuse.__main__:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/deefuse/__main__.py
+++ b/src/deefuse/__main__.py
@@ -1,4 +1,4 @@
-from .ui.main_window import App   # relative import (the dot is important)
+from deefuse.ui.main_window import App
 
 
 def main() -> None:               # noqa: D401


### PR DESCRIPTION
## Summary
- reference the main GUI with an absolute import
- search for packages under `src/`
- build the Windows executable by calling PyInstaller on the entry script
- document the PyInstaller command in the README
- remove the stray root `src` package

## Testing
- `python -m py_compile $(git ls-files '*.py')`