### PR TITLE
Use embedded icon for Windows exe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,10 @@ jobs:
 
       - name: Build EXE with PyInstaller
         run: |
-          pyinstaller --noconsole --onefile -n DeeFuse run_deefuse.py
+          pyinstaller --noconsole --onefile \
+            --icon assets/deefuse_desktop.ico \
+            --add-data "assets/deefuse_desktop.ico;assets" \
+            -n DeeFuse run_deefuse.py
 
       - name: Upload EXE to GitHub Release
         uses: softprops/action-gh-release@v1

--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ This will install a `deefuse` entry point.
 Use PyInstaller's module mode to bundle the application:
 
 ```bash
-pyinstaller --noconsole --onefile -n DeeFuse -m deefuse
+pyinstaller --noconsole --onefile \
+  --icon assets/deefuse_desktop.ico \
+  --add-data "assets/deefuse_desktop.ico;assets" \
+  -n DeeFuse -m deefuse
 ```
 
 Running in module mode ensures the package context is correctly set when the

--- a/src/deefuse/ui/main_window.py
+++ b/src/deefuse/ui/main_window.py
@@ -13,7 +13,11 @@ from .progress_dialog import ProgressDialog
 class App(ctk.CTk):
     def __init__(self):
         super().__init__()
-        self.iconbitmap("assets/deefuse_desktop.ico")
+        icon = utils.asset_path("assets/deefuse_desktop.ico")
+        try:
+            self.iconbitmap(icon)
+        except Exception:
+            pass
         self.title("DeeFuse")
         self.geometry("1400x880")
         self.minsize(1200, 700)

--- a/src/deefuse/utils.py
+++ b/src/deefuse/utils.py
@@ -1,6 +1,7 @@
 import os
 import re
 import difflib
+import sys
 from deefuse.config import DURATION_TOLERANCE_SEC
 
 # ── REGEX FOR PARSING ───────────────────────────────────────────────────
@@ -56,3 +57,9 @@ def normalize_relaxed_title(title: str) -> str:
 def get_string_ratio(a: str, b: str) -> float:
     """Calculates the similarity ratio between two strings."""
     return difflib.SequenceMatcher(None, a, b).ratio()
+
+
+def asset_path(relative: str) -> str:
+    """Return absolute path to resource, works for dev and PyInstaller."""
+    base = getattr(sys, "_MEIPASS", os.path.abspath(os.path.dirname(__file__)))
+    return os.path.join(base, relative)


### PR DESCRIPTION
## Summary
- support proper resource path lookups
- load icon using `utils.asset_path` in the UI
- bundle icon in PyInstaller builds
- document the icon flag in build instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68704333dd98832aa040bbd049f7c697