### PR TITLE
Add configurable settings UI

### DIFF
--- a/src/deefuse/__init__.py
+++ b/src/deefuse/__init__.py
@@ -6,6 +6,7 @@ and defines the package version.
 """
 __all__ = [
     "config",
+    "settings",
     "utils",
     "csv_handler",
     "deezer_api",

--- a/src/deefuse/config.py
+++ b/src/deefuse/config.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
+import os
+from .settings import settings, Settings
+
 # ── FILE & PATHS ────────────────────────────────────────────────────────
-SKIPPED_CSV = "skipped_tracks.csv"
-MATCHED_CSV = "matched_tracks.csv"
+SKIPPED_CSV = ""
+MATCHED_CSV = ""
 DOWNLOAD_PATH = None  # None ⇒ uses the default deemix download folder
 
 # ── DEEMIX & API SETTINGS ───────────────────────────────────────────────
 DEEMIX_CLI = "deemix"
-BITRATES_PREFER = ["flac", "320"]  # try FLAC first, then 320-kbps MP3
+BITRATES_PREFER = []
 DEEZER_API_URL = "https://api.deezer.com/search"
 
 # ── SCANNING & MATCHING ─────────────────────────────────────────────────
@@ -17,5 +22,21 @@ SKIP_HDR = ["Track", "Artist", "Album", "Duration"]
 MATCH_HDR = [
     "Local Track", "Local Artist", "Local Album", "Local Duration",
     "Deezer Track", "Deezer Artist", "Deezer Album", "Deezer Duration",
-    "Deezer URL"
+    "Deezer URL",
 ]
+
+
+def reload_settings(s: Settings = settings) -> None:
+    """Update module globals based on stored settings."""
+    global SKIPPED_CSV, MATCHED_CSV, BITRATES_PREFER
+    csv_dir = os.path.expanduser(s.csv_dir)
+    os.makedirs(csv_dir, exist_ok=True)
+    SKIPPED_CSV = os.path.join(csv_dir, "skipped_tracks.csv")
+    MATCHED_CSV = os.path.join(csv_dir, "matched_tracks.csv")
+    if s.target_quality == "flac":
+        BITRATES_PREFER[:] = ["flac", "320"]
+    else:
+        BITRATES_PREFER[:] = ["320"]
+
+
+reload_settings()

--- a/src/deefuse/settings.py
+++ b/src/deefuse/settings.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, asdict
+from pathlib import Path
+
+
+DEFAULT_DIR = Path.home() / "Documents" / "Deefuse"
+SETTINGS_FILE = DEFAULT_DIR / "settings.json"
+
+
+@dataclass
+class Settings:
+    auto_search_on_click: bool = True
+    csv_dir: str = str(DEFAULT_DIR)
+    target_quality: str = "flac"  # "flac" or "320"
+
+
+def load_settings() -> Settings:
+    DEFAULT_DIR.mkdir(parents=True, exist_ok=True)
+    if SETTINGS_FILE.exists():
+        try:
+            with open(SETTINGS_FILE, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            return Settings(**{**asdict(Settings()), **data})
+        except Exception:
+            pass
+    return Settings()
+
+
+def save_settings(settings: Settings) -> None:
+    SETTINGS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with open(SETTINGS_FILE, "w", encoding="utf-8") as f:
+        json.dump(asdict(settings), f, indent=2)
+
+
+# Global settings instance loaded at import time
+settings = load_settings()

--- a/src/deefuse/ui/__init__.py
+++ b/src/deefuse/ui/__init__.py
@@ -1,5 +1,6 @@
 """GUI sub-package: windows, dialogs, and any future widgets."""
 from .main_window import App
 from .progress_dialog import ProgressDialog
+from .settings_window import SettingsWindow
 
-__all__ = ["App", "ProgressDialog"]
+__all__ = ["App", "ProgressDialog", "SettingsWindow"]

--- a/src/deefuse/ui/main_window.py
+++ b/src/deefuse/ui/main_window.py
@@ -7,6 +7,8 @@ from mutagen import File as MutagenFile
 
 # Import from our refactored modules
 from deefuse import utils, config, csv_handler, downloader, deezer_api
+from deefuse.settings import settings
+from .settings_window import SettingsWindow
 from .progress_dialog import ProgressDialog
 
 
@@ -142,6 +144,7 @@ class App(ctk.CTk):
                       hover_color="#23913c").pack(side="left", padx=6)
         ctk.CTkButton(btn_row, text="Clear Progress", command=self._clear_download_progress, fg_color="#ffc107",
                       hover_color="#d39e00").pack(side="left", padx=6)
+        ctk.CTkButton(btn_row, text="Settings", command=self._open_settings).pack(side="left", padx=6)
         ctk.CTkButton(btn_row, text="Exit", command=self.destroy, fg_color="#dc3545", hover_color="#bd2c3a").pack(
             side="right", padx=6)
 
@@ -256,13 +259,16 @@ class App(ctk.CTk):
         for row in self.skipped_rows:
             self.skip_tv.insert("", "end", values=row)
 
-    def _on_skipped_track_select(self, event=None):
-        """When a skipped track is selected, perform a relaxed search on Deezer."""
+    def _on_skipped_track_select(self, event=None, manual=False):
+        """Handle selecting a skipped track and optionally search Deezer."""
         selected_item = self.skip_tv.selection()
         if not selected_item:
             return
 
         self._show_detail_view(event)
+
+        if event is not None and not manual and not settings.auto_search_on_click:
+            return
 
         selected_row = self.skip_tv.item(selected_item[0])["values"]
         track_title, artist_name = selected_row[0], selected_row[1]
@@ -283,7 +289,7 @@ class App(ctk.CTk):
         if not self.skip_tv.selection():
             messagebox.showinfo("Info", "Select a track from the 'Skipped Tracks' list to search for it.")
             return
-        self._on_skipped_track_select()
+        self._on_skipped_track_select(manual=True)
 
     def _on_deezer_result_double_click(self, event):
         """Handles double-clicking a result in the Deezer table to start a download."""
@@ -386,3 +392,12 @@ class App(ctk.CTk):
         self.detail_textbox.delete("1.0", "end")
         self.detail_textbox.insert("end", detail_text)
         self.detail_textbox.configure(state="disabled")
+
+    def _open_settings(self):
+        """Open the settings window."""
+        SettingsWindow(self, on_save=self._settings_saved)
+
+    def _settings_saved(self):
+        """Reload data when settings have been changed."""
+        self.skipped_rows, _ = csv_handler.load_skipped()
+        self.event_generate("<<RefreshUI>>")

--- a/src/deefuse/ui/settings_window.py
+++ b/src/deefuse/ui/settings_window.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import customtkinter as ctk
+from tkinter import filedialog
+from ..settings import settings, save_settings, Settings
+from .. import config
+
+
+class SettingsWindow(ctk.CTkToplevel):
+    def __init__(self, parent, on_save=None):
+        super().__init__(parent)
+        self.on_save = on_save
+        self.title("Settings")
+        self.geometry("420x220")
+        self.resizable(False, False)
+
+        self.auto_var = ctk.BooleanVar(value=settings.auto_search_on_click)
+        self.csv_var = ctk.StringVar(value=settings.csv_dir)
+        self.quality_var = ctk.StringVar(value=settings.target_quality)
+
+        self._build_ui()
+
+    def _build_ui(self):
+        pad = {"padx": 20, "pady": 6}
+        ctk.CTkCheckBox(
+            self,
+            text="Search skipped tracks on click",
+            variable=self.auto_var,
+        ).pack(anchor="w", **pad)
+
+        dir_frame = ctk.CTkFrame(self, fg_color="transparent")
+        dir_frame.pack(fill="x", **pad)
+        ctk.CTkLabel(dir_frame, text="CSV Directory:").grid(row=0, column=0, sticky="w")
+        entry = ctk.CTkEntry(dir_frame, textvariable=self.csv_var, width=240)
+        entry.grid(row=0, column=1, sticky="ew", padx=(10, 0))
+        dir_frame.columnconfigure(1, weight=1)
+        ctk.CTkButton(dir_frame, text="Browse", command=self._browse_csv).grid(row=0, column=2, padx=6)
+
+        qual_frame = ctk.CTkFrame(self, fg_color="transparent")
+        qual_frame.pack(fill="x", **pad)
+        ctk.CTkLabel(qual_frame, text="Target Quality:").grid(row=0, column=0, sticky="w")
+        ctk.CTkOptionMenu(qual_frame, values=["flac", "320"], variable=self.quality_var).grid(
+            row=0, column=1, sticky="w", padx=(10, 0)
+        )
+
+        btn_frame = ctk.CTkFrame(self, fg_color="transparent")
+        btn_frame.pack(pady=10)
+        ctk.CTkButton(btn_frame, text="Save", command=self._save).pack(side="left", padx=10)
+        ctk.CTkButton(btn_frame, text="Cancel", command=self.destroy).pack(side="left", padx=10)
+
+    def _browse_csv(self):
+        path = filedialog.askdirectory(initialdir=self.csv_var.get())
+        if path:
+            self.csv_var.set(path)
+
+    def _save(self):
+        settings.auto_search_on_click = self.auto_var.get()
+        settings.csv_dir = self.csv_var.get()
+        settings.target_quality = self.quality_var.get()
+        save_settings(settings)
+        config.reload_settings(settings)
+        if callable(self.on_save):
+            self.on_save()
+        self.destroy()


### PR DESCRIPTION
## Summary
- implement settings storage in `settings.py`
- reload config from settings
- add a Settings window and integrate into main app
- allow choosing CSV directory, target quality, and auto search behavior
- export settings utilities

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68718ac78b2c832a88b858adac306a15